### PR TITLE
Export 'denominator'

### DIFF
--- a/src/Data/Fixed.purs
+++ b/src/Data/Fixed.purs
@@ -12,6 +12,7 @@ module Data.Fixed
   , toString
   , toStringWithPrecision
   , numerator
+  , denominator
   , floor
   , ceil
   , round


### PR DESCRIPTION
This is useful for converting to Rational, and is probably an accidental
omission given that `numerator` is already exported.